### PR TITLE
Make CV template mobile-friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 data/cv.json
+utils/*

--- a/src/cv.css
+++ b/src/cv.css
@@ -13,13 +13,14 @@
     --font-size-base: 0.8rem;
     --font-size-large: 1rem;
     --font-size-h1: 1.5rem;
-    --font-size-h2: 1.1rem;
+    --font-size-h2: 1.2rem;
+    --font-size-h3: 1rem;
     --font-weight-bold: 700;
 
     /* Layout */
-    --max-width: 90%;
-    --main-width: 70%;
-    --sidebar-width: 30%;
+    --max-width: 48rem;
+    --main-width: 34rem;
+    --sidebar-width: 14rem;
     --spacing: 1rem;
 
     /* Breakpoints */
@@ -103,6 +104,11 @@ h2 {
     padding: 0.8rem 0 0 0;
 }
 
+h3 {
+    font-size: var(--font-size-h3);
+    font-weight: var(--font-weight-bold);
+}
+
 i {
     color: var(--color-highlight-dark);
     font-style: normal;
@@ -119,10 +125,7 @@ header,
 main,
 footer {
     width: var(--max-width);
-    max-width: 48rem;
     margin: 0 auto;
-    padding-left: var(--spacing);
-    padding-right: var(--spacing);
 }
 
 /* Header */
@@ -133,7 +136,6 @@ header {
     justify-content: space-between;
     align-items: flex-start;
     padding: var(--spacing) 0;
-    gap: var(--spacing);
 }
 
 header h1,
@@ -162,31 +164,35 @@ footer a:hover {
 /* Main Container */
 .main-container {
     background-color: var(--color-light);
-    width: 100%;
 }
 
 main {
     max-width: var(--max-width);
-    padding: var(--spacing) 0 var(--spacing) 0;
+    padding: 0 0 var(--spacing) 0;
     color: var(--color-dark);
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
     align-items: flex-start;
-    gap: var(--spacing);
 }
 
 main h3 {
     padding: 0.3rem 0 0 0;
 }
 
+
 main ul {
     list-style-type: disc;
+    margin-left: 0.5rem;
     padding-left: var(--spacing);
     padding-bottom: 0.3rem;
 }
 
 /* Sections */
+section {
+    padding: 0 var(--spacing);
+}
+
 section.summary {
     width: var(--main-width);
 }
@@ -194,12 +200,11 @@ section.summary {
 section.contacts {
     min-width: var(--sidebar-width);
     max-width: var(--sidebar-width);
-    padding-left: 0.5rem;
 }
 
 section.contacts ul {
     list-style: none;
-    padding-left: 0;
+    /*padding-left: 0;*/
 }
 
 section.contacts li {
@@ -209,14 +214,12 @@ section.contacts li {
 section.experience,
 section.education {
     width: var(--main-width);
-    padding-right: 0.5rem;
 }
 
 section.skills,
 section.additional-info {
     min-width: var(--sidebar-width);
     max-width: var(--sidebar-width);
-    padding-left: 0.5rem;
 }
 
 /* Footer */
@@ -307,39 +310,49 @@ main a:visited {
 /* Mobile Responsive Styles */
 @media screen and (max-width: 768px) {
     :root {
-        --max-width: 95%;
-        --font-size-base: 0.9rem;
-        --font-size-large: 1.1rem;
+        --max-width: 100%;
+        --main-width: 100%;
+        --sidebar-width: 100%;
+        /*--font-size-base: 0.9rem;*/
+        /*--font-size-large: 1.1rem;*/
     }
 
     header {
         flex-direction: column;
+        gap: var(--spacing);
     }
 
-    section.summary,
-    section.contacts,
-    section.experience,
-    section.education,
-    section.skills,
-    section.additional-info {
+    section {
         width: 100%;
         min-width: 100%;
         max-width: 100%;
-        padding-left: 0;
-        padding-right: 0;
     }
 
     main {
         flex-direction: column;
+        gap: var(--spacing);
+        /*padding: var(--spacing) 0;*/
+    }
+
+    main h3 {
+        word-break: break-word;
+        hyphens: auto;
+    }
+
+    main h3 i {
+        display: table-column;
+    }
+
+    main h3 a:first-of-type::before {
+        content: '@ ';
     }
 
     section.contacts {
-        margin-top: 1rem;
+        margin-top: 0.5rem;
     }
 
     /* Improve touch targets for mobile */
     a, .theEmail a, .theEmailRequest {
-        padding: 0.3rem 0;
         display: inline-block;
     }
 
@@ -350,29 +363,23 @@ main a:visited {
 
 @media screen and (max-width: 480px) {
     :root {
-        --font-size-base: 0.85rem;
-        --font-size-h1: 1.3rem;
-        --font-size-h2: 1rem;
-        --spacing: 0.7rem;
+        /*--font-size-base: 0.85rem;*/
+        /*--font-size-h1: 1.3rem;*/
+        /*--font-size-h2: 1.2rem;*/
+        /*--font-size-h3: 1.1rem;*/
+        /*--spacing: 0.7rem;*/
     }
 
-    header h1,
-    header h2 {
-        height: auto;
-    }
+/*    main ul {*/
+/*        margin-left: 1em;*/
+/*    }*/
 
-    /* Adjust experience section for very small screens */
-    main h3 {
-        word-break: break-word;
-        hyphens: auto;
-    }
-
-    /* Ensure proper padding on small screens */
-    header, main, footer {
-        padding-left: 0.5rem;
-        padding-right: 0.5rem;
-    }
-}
+/*    !* Ensure proper padding on small screens *!*/
+/*    header, main, footer {*/
+/*        padding-left: 0.5rem;*/
+/*        padding-right: 0.5rem;*/
+/*    }*/
+/*}*/
 
 @media print {
     body,

--- a/src/cv.css
+++ b/src/cv.css
@@ -25,7 +25,6 @@
 
     /* Breakpoints */
     --mobile-breakpoint: 768px;
-    --small-mobile-breakpoint: 480px;
 }
 
 /* Reset */
@@ -189,7 +188,7 @@ main ul {
 }
 
 /* Sections */
-section {
+section:nth-child(odd) {
     padding: 0 var(--spacing);
 }
 
@@ -204,7 +203,6 @@ section.contacts {
 
 section.contacts ul {
     list-style: none;
-    /*padding-left: 0;*/
 }
 
 section.contacts li {
@@ -224,7 +222,7 @@ section.additional-info {
 
 /* Footer */
 footer {
-    padding: var(--spacing) 0;
+    padding: var(--spacing);
     text-align: left;
 }
 
@@ -319,19 +317,23 @@ main a:visited {
 
     header {
         flex-direction: column;
-        gap: var(--spacing);
+        /*gap: var(--spacing);*/
     }
 
     section {
         width: 100%;
         min-width: 100%;
         max-width: 100%;
+        padding: 0;
     }
+
+    section:nth-child(even) {
+        padding: 0 var(--spacing);
+    }
+
 
     main {
         flex-direction: column;
-        gap: var(--spacing);
-        /*padding: var(--spacing) 0;*/
     }
 
     main h3 {
@@ -361,27 +363,13 @@ main a:visited {
     }
 }
 
-@media screen and (max-width: 480px) {
+@media print {
     :root {
-        /*--font-size-base: 0.85rem;*/
-        /*--font-size-h1: 1.3rem;*/
-        /*--font-size-h2: 1.2rem;*/
-        /*--font-size-h3: 1.1rem;*/
-        /*--spacing: 0.7rem;*/
+        --font-size-base: 0.8rem;
+        --font-size-large: 1rem;
+        --spacing: 0.5rem;
     }
 
-/*    main ul {*/
-/*        margin-left: 1em;*/
-/*    }*/
-
-/*    !* Ensure proper padding on small screens *!*/
-/*    header, main, footer {*/
-/*        padding-left: 0.5rem;*/
-/*        padding-right: 0.5rem;*/
-/*    }*/
-/*}*/
-
-@media print {
     body,
     a,
     .thePhone::before,
@@ -415,6 +403,10 @@ main a:visited {
         padding: 0;
     }
 
+    section.skills {
+        padding-left: 0.5rem;
+    }
+
     .main-container {
         background-color: transparent;
     }
@@ -424,7 +416,7 @@ main a:visited {
     }
 
     footer {
-        padding: 0.5rem 0;
+        padding: 0.5rem;
     }
 
     .print {

--- a/src/cv.css
+++ b/src/cv.css
@@ -17,10 +17,14 @@
     --font-weight-bold: 700;
 
     /* Layout */
-    --max-width: 48rem;
-    --main-width: 34rem;
-    --sidebar-width: 14rem;
+    --max-width: 90%;
+    --main-width: 70%;
+    --sidebar-width: 30%;
     --spacing: 1rem;
+
+    /* Breakpoints */
+    --mobile-breakpoint: 768px;
+    --small-mobile-breakpoint: 480px;
 }
 
 /* Reset */
@@ -115,7 +119,10 @@ header,
 main,
 footer {
     width: var(--max-width);
+    max-width: 48rem;
     margin: 0 auto;
+    padding-left: var(--spacing);
+    padding-right: var(--spacing);
 }
 
 /* Header */
@@ -126,6 +133,7 @@ header {
     justify-content: space-between;
     align-items: flex-start;
     padding: var(--spacing) 0;
+    gap: var(--spacing);
 }
 
 header h1,
@@ -154,16 +162,18 @@ footer a:hover {
 /* Main Container */
 .main-container {
     background-color: var(--color-light);
+    width: 100%;
 }
 
 main {
     max-width: var(--max-width);
-    padding: 0 0 var(--spacing) 0;
+    padding: var(--spacing) 0 var(--spacing) 0;
     color: var(--color-dark);
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
     align-items: flex-start;
+    gap: var(--spacing);
 }
 
 main h3 {
@@ -291,6 +301,76 @@ main a:visited {
 @media screen {
     .print {
         display: none;
+    }
+}
+
+/* Mobile Responsive Styles */
+@media screen and (max-width: 768px) {
+    :root {
+        --max-width: 95%;
+        --font-size-base: 0.9rem;
+        --font-size-large: 1.1rem;
+    }
+
+    header {
+        flex-direction: column;
+    }
+
+    section.summary,
+    section.contacts,
+    section.experience,
+    section.education,
+    section.skills,
+    section.additional-info {
+        width: 100%;
+        min-width: 100%;
+        max-width: 100%;
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    main {
+        flex-direction: column;
+    }
+
+    section.contacts {
+        margin-top: 1rem;
+    }
+
+    /* Improve touch targets for mobile */
+    a, .theEmail a, .theEmailRequest {
+        padding: 0.3rem 0;
+        display: inline-block;
+    }
+
+    section.contacts li {
+        margin-bottom: 0.5rem;
+    }
+}
+
+@media screen and (max-width: 480px) {
+    :root {
+        --font-size-base: 0.85rem;
+        --font-size-h1: 1.3rem;
+        --font-size-h2: 1rem;
+        --spacing: 0.7rem;
+    }
+
+    header h1,
+    header h2 {
+        height: auto;
+    }
+
+    /* Adjust experience section for very small screens */
+    main h3 {
+        word-break: break-word;
+        hyphens: auto;
+    }
+
+    /* Ensure proper padding on small screens */
+    header, main, footer {
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
     }
 }
 


### PR DESCRIPTION
This PR implements mobile responsiveness for the CV template by:

- Adding responsive CSS variables using percentages instead of fixed widths
- Creating media queries for different screen sizes (mobile, tablet, desktop)
- Adjusting the layout to stack sections vertically on smaller screens
- Improving typography and spacing for better readability on mobile devices
- Enhancing touch targets for better mobile usability

Fixes #10