### PR TITLE
feat: ATS-ready one-page print layout (US Letter)

### DIFF
--- a/data/cv.json
+++ b/data/cv.json
@@ -90,7 +90,7 @@
       "endDate": "2019-02",
       "achievements": [
         "Enhanced manufacturing data management through database migration and modernized <a href='https://en.wikipedia.org/wiki/Extract,_transform,_load'>ETL</a> infrastructure.",
-        "Delivered a refactored <a href='https://en.wikipedia.org/wiki/Extract,_transform,_load'>ETL</a> orchestrator, including an orchestrator with 85% unit test coverage, robust monitoring <a href='https://prometheus.io/'>Prometheus</a>, <a href='https://grafana.com/'>Grafana</a>), and a scalable configuration service <a href='https://learn.microsoft.com/en-us/aspnet/core/web-api/'>ASP.NET WebAPI</a>, <a href='https://en.wikipedia.org/wiki/CI/CD'>CI/CD</a>).",
+        "Delivered a refactored <a href='https://en.wikipedia.org/wiki/Extract,_transform,_load'>ETL</a> orchestrator, including an orchestrator with 85% unit test coverage, robust monitoring (<a href='https://prometheus.io/'>Prometheus</a>, <a href='https://grafana.com/'>Grafana</a>), and a scalable configuration service (<a href='https://learn.microsoft.com/en-us/aspnet/core/web-api/'>ASP.NET WebAPI</a>, <a href='https://en.wikipedia.org/wiki/CI/CD'>CI/CD</a>).",
         "Developed a customer onboarding portal (<a href='https://en.wikipedia.org/wiki/ASP.NET_MVC'>ASP.NET MVC</a>)."
       ]
     },

--- a/src/cv.css
+++ b/src/cv.css
@@ -441,10 +441,10 @@ main a:visited {
 /* ==========================================================================
    Media Queries
    ========================================================================== */
-@media screen {
-    .print {
-        display: none;
-    }
+/* Print-only elements (this stylesheet is loaded with media="screen";
+   print styling lives in cv.print.css) */
+.print {
+    display: none;
 }
 
 /* Mobile Responsive Styles */
@@ -502,89 +502,6 @@ main a:visited {
 
     section.contacts li {
         margin-bottom: 0.5rem;
-    }
-}
-
-@media print {
-    /* Reset theme variables for printing */
-    :root, [data-theme="dark"], [data-theme="light"] {
-        --color-text: black;
-        --color-bg: white;
-        --color-header-text: black;
-        --color-header-bg: white;
-        --color-highlight-primary: black;
-        --color-highlight-secondary: black;
-        --font-size-base: 0.8rem;
-        --font-size-large: 1rem;
-        --spacing: 0.5rem;
-    }
-
-    /* Hide theme toggle and tooltip in print */
-    .theme-toggle,
-    .theme-toggle::after {
-        display: none;
-    }
-  
-    body,
-    a,
-    .thePhone::before,
-    .theEmail::before,
-    span,
-    strong,
-    i,
-    em,
-    b {
-        color: black !important;
-        background-color: transparent !important;
-        text-decoration: none !important;
-    }
-
-    em,
-    i {
-        font-style: italic !important;
-    }
-
-    strong,
-    b {
-        font-weight: bold !important;
-    }
-
-    section.summary a {
-        font-style: italic;
-        color: black;
-    }
-
-    main {
-        padding: 0;
-    }
-
-    section.skills {
-        padding-left: 0.5rem;
-    }
-
-    .main-container {
-        background-color: transparent;
-    }
-
-    .web {
-        display: none;
-    }
-
-    footer {
-        padding: 0.5rem;
-    }
-
-    .print {
-        line-height: 1.4rem;
-        display: inline-block;
-    }
-
-    .intend {
-        padding-left: 1rem;
-    }
-
-    footer * {
-        color: black !important;
     }
 }
 

--- a/src/cv.html
+++ b/src/cv.html
@@ -2,7 +2,8 @@
 <html lang="en">
     <head>
         <title>CV</title>
-        <link href="./cv.css" rel="stylesheet" type="text/css" />
+        <link href="./cv.css" rel="stylesheet" type="text/css" media="screen" />
+        <link href="./cv.print.css" rel="stylesheet" type="text/css" media="print" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport" />
         <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
         <meta content="Alexei Darii" name="author" />
@@ -29,7 +30,7 @@
         <div class="main-container">
             <main>
                 <section class="experience">
-                    <h2>Relevant Work Experience</h2>
+                    <h2>Work Experience</h2>
                 </section>
                 <section class="skills">
                     <h2>Skills</h2>

--- a/src/cv.print.css
+++ b/src/cv.print.css
@@ -1,0 +1,165 @@
+/* ==========================================================================
+   Print / ATS Stylesheet
+   Loaded with media="print" while cv.css is media="screen", so this file
+   fully defines the printed document. Goal: a single-column, black-on-white,
+   machine-parsable layout that Applicant Tracking Systems can read reliably.
+   ========================================================================== */
+
+@page {
+    size: letter;
+    margin: 10mm 14mm;
+}
+
+/* Reset */
+html,
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+ol,
+ul,
+li {
+    margin: 0;
+    padding: 0;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    color: black !important;
+    background: transparent !important;
+}
+
+/* ATS-safe base typography */
+body {
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 9.5pt;
+    line-height: 1.25;
+    color: black;
+    background: white;
+}
+
+/* Single-column, source-order layout: ATS parsers read multi-column
+   pages left-to-right and scramble the content. */
+header,
+main,
+footer,
+.main-container,
+section {
+    display: block;
+    width: 100%;
+    max-width: none;
+    min-width: 0;
+    margin: 0;
+    padding: 0;
+}
+
+h1 {
+    font-size: 15pt;
+}
+
+h2 {
+    font-size: 11.5pt;
+    margin-top: 5pt;
+    border-bottom: 1pt solid black;
+}
+
+h3 {
+    font-size: 10pt;
+    margin-top: 4pt;
+}
+
+/* Keep headings attached to their content and bullets unsplit across pages */
+h1,
+h2,
+h3 {
+    break-after: avoid;
+    page-break-after: avoid;
+}
+
+ul {
+    list-style: disc;
+    margin: 1pt 0 3pt 14pt;
+}
+
+li {
+    break-inside: avoid;
+    page-break-inside: avoid;
+}
+
+.dates {
+    font-style: italic;
+}
+
+a {
+    color: black;
+    text-decoration: none;
+}
+
+em,
+i {
+    font-style: italic;
+}
+
+strong,
+b {
+    font-weight: bold;
+}
+
+/* Hide screen-only chrome; show print-only alternatives (bare URLs, etc.) */
+.theme-toggle,
+.web {
+    display: none !important;
+}
+
+.print {
+    display: inline;
+}
+
+/* Skills-type lists print inline, comma-separated: one word per bullet line
+   wastes the vertical space needed to keep the document on one page. */
+section.skills ul,
+section.additional-info ul {
+    list-style: none;
+    margin-left: 0;
+}
+
+section.skills li,
+section.additional-info li {
+    display: inline;
+}
+
+section.skills li:not(:last-child)::after {
+    content: ", ";
+}
+
+/* Contact lines: plain text labels instead of the on-screen glyph icons,
+   so parsers can classify each line. */
+section.contacts ul {
+    list-style: none;
+    margin-left: 0;
+}
+
+.theContactsLocation::before {
+    content: "Location: ";
+    font-weight: bold;
+}
+
+.thePhone::before {
+    content: "Phone: ";
+    font-weight: bold;
+}
+
+.theEmail::before {
+    content: "Email: ";
+    font-weight: bold;
+}
+
+footer {
+    margin-top: 5pt;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
     base: "./",
     build: {
+        // Never inline assets as data: URIs — the CSP (style-src 'self') forbids them
+        assetsInlineLimit: 0,
         rollupOptions: {
             input: resolve(__dirname, "src/cv.html"),
             output: {


### PR DESCRIPTION
## Summary
- Dedicated print stylesheet (`cv.print.css`, `media="print"`): single-column source-order layout, Arial black-on-white, labeled `Location:`/`Phone:`/`Email:` contact lines, inline comma-separated skill lists, page-break control — fits one US Letter page
- `cv.css` scoped to `media="screen"`; its old `@media print` block removed
- Standard ATS heading: "Relevant Work Experience" → "Work Experience"
- `assetsInlineLimit: 0` in Vite config — inlined `data:` stylesheets are blocked by the CSP
- Fixed two missing opening parentheses in `data/cv.json` achievements

## Verification
Built and printed with headless Chromium: 1 page, 612×792 pts (Letter); text extraction (what an ATS sees) comes out in correct linear order. Screen rendering unchanged (screenshot-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)